### PR TITLE
Allow CORs to lib to work with AWS Lamba Chi Adapter

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -192,6 +192,8 @@ func (c *Cors) Handler(next http.Handler) http.Handler {
 			// headers (see #1)
 			if c.optionPassthrough {
 				next.ServeHTTP(w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
 			}
 		} else {
 			c.logf("Handler: Actual request")


### PR DESCRIPTION
The adapter (https://github.com/awslabs/aws-lambda-go-api-proxy) doesn't automatically set the 200 response code like `net/http` does. This small change is required to make it work.