### PR TITLE
Added func to look up Origin value, if not from the Origin header

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -116,6 +116,7 @@ func New(options Options) *Cors {
 
 	c := &Cors{
 		exposedHeaders:    convert(options.ExposedHeaders, http.CanonicalHeaderKey),
+		allowOriginFunc:   options.AllowOriginFunc,
 		lookupOriginFunc:  options.LookupOriginFunc,
 		allowCredentials:  options.AllowCredentials,
 		maxAge:            options.MaxAge,
@@ -207,6 +208,8 @@ func (c *Cors) Handler(next http.Handler) http.Handler {
 			// headers (see #1)
 			if c.optionPassthrough {
 				next.ServeHTTP(w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
 			}
 		} else {
 			c.logf("Handler: Actual request")


### PR DESCRIPTION
#11 - Simple fix for adding a lookup function for an Origin value.  Defaults to `r.Header.Get("Origin")`