### PR TITLE
Might be useful for some headers with same prefix

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -359,7 +359,7 @@ func (c *Cors) areHeadersAllowed(requestedHeaders []string) bool {
 		header = http.CanonicalHeaderKey(header)
 		found := false
 		for _, h := range c.allowedHeaders {
-			if h == header {
+			if strings.Index(header, h) == 0 {
 				found = true
 			}
 		}


### PR DESCRIPTION
```X-Upload``` allows ```X-Upload-Chunk``` or ```X-Upload-Id```