### PR TITLE
Allow underscores on headers

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -51,7 +51,7 @@ func parseHeaderList(headerList string) []string {
 			} else {
 				h = append(h, b)
 			}
-		} else if b == '-' || (b >= '0' && b <= '9') {
+		} else if b == '-' || b == '_' || (b >= '0' && b <= '9') {
 			h = append(h, b)
 		}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -32,19 +32,19 @@ func TestConvert(t *testing.T) {
 }
 
 func TestParseHeaderList(t *testing.T) {
-	h := parseHeaderList("header, second-header, THIRD-HEADER, Numb3r3d-H34d3r")
-	e := []string{"Header", "Second-Header", "Third-Header", "Numb3r3d-H34d3r"}
-	if h[0] != e[0] || h[1] != e[1] || h[2] != e[2] {
+	h := parseHeaderList("header, second-header, THIRD-HEADER, Numb3r3d-H34d3r, Header_with_underscore")
+	e := []string{"Header", "Second-Header", "Third-Header", "Numb3r3d-H34d3r", "Header_with_underscore"}
+	if h[0] != e[0] || h[1] != e[1] || h[2] != e[2] || h[3] != e[3] || h[4] != e[4] {
 		t.Errorf("%v != %v", h, e)
 	}
 }
 
 func TestParseHeaderListEmpty(t *testing.T) {
 	if len(parseHeaderList("")) != 0 {
-		t.Error("should be empty sclice")
+		t.Error("should be empty slice")
 	}
 	if len(parseHeaderList(" , ")) != 0 {
-		t.Error("should be empty sclice")
+		t.Error("should be empty slice")
 	}
 }
 


### PR DESCRIPTION
* fix spelling mistakes
* fix a header not being tested
* allow underscores on headers

Underscores are allowed in headers according to the http spec: https://stackoverflow.com/questions/22856136/why-do-http-servers-forbid-underscores-in-http-header-names.

Ran into this problem with code I am writing for a to be production server. The code throws no warnings and just silently removes the _'s leaving cors to fail the request.
