### PR TITLE
Support pre-parsed headers

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -3,15 +3,15 @@
 //
 // You can configure it by passing an option struct to cors.New:
 //
-//     c := cors.New(cors.Options{
-//         AllowedOrigins: []string{"foo.com"},
-//         AllowedMethods: []string{"GET", "POST", "DELETE"},
-//         AllowCredentials: true,
-//     })
+//	c := cors.New(cors.Options{
+//	    AllowedOrigins: []string{"foo.com"},
+//	    AllowedMethods: []string{"GET", "POST", "DELETE"},
+//	    AllowCredentials: true,
+//	})
 //
 // Then insert the handler in the chain:
 //
-//     handler = c.Handler(handler)
+//	handler = c.Handler(handler)
 //
 // See Options documentation for more options.
 //
@@ -261,12 +261,18 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// We need to call Values func instead of Get because the header might
+	// be parsed/split before it reaches the handler. Calling "Get" will only
+	// return the first value This guarantees that we get all values of
+	// the header and maintains the original functionality.
 	headerVals := r.Header.Values("Access-Control-Request-Headers")
 
 	c.logf("Preflight access control request headers: %v", headerVals)
 
 	var reqHeaders []string
 
+	// loop over the header values and parse them; this will allow us to handle
+	// the case where it's a single comma separated header or multiple headers
 	for _, headerVal := range headerVals {
 		parsed := parseHeaderList(headerVal)
 		reqHeaders = append(reqHeaders, parsed...)

--- a/cors.go
+++ b/cors.go
@@ -260,7 +260,17 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		c.logf("Preflight aborted: method '%s' not allowed", reqMethod)
 		return
 	}
-	reqHeaders := parseHeaderList(r.Header.Get("Access-Control-Request-Headers"))
+
+	headerVals := r.Header.Values("Access-Control-Request-Headers")
+
+	c.logf("Preflight access control request headers: %v", headerVals)
+
+	var reqHeaders []string
+
+	for _, headerVal := range headerVals {
+		parsed := parseHeaderList(headerVal)
+		reqHeaders = append(reqHeaders, parsed...)
+	}
 	if !c.areHeadersAllowed(reqHeaders) {
 		c.logf("Preflight aborted: headers '%v' not allowed", reqHeaders)
 		return

--- a/cors_test.go
+++ b/cors_test.go
@@ -297,7 +297,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Allow-Methods": "GET",
 				"Access-Control-Allow-Headers": "X-Header-2, X-Header-1",
 			},
-			false,
+			true,
 		},
 		{
 			"DefaultAllowedHeaders",


### PR DESCRIPTION
Resolves Issue #33

Support pre-parsed headers for Access-Origin-Allow-Headers since they might be pre parsed by wrappers such as the AWS  Lambda Go API Proxy.

Please review @pkieltyka  @VojtechVitek