### PR TITLE
Fix Origin header check

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -210,7 +210,10 @@ func AllowAll() *Cors {
 // as necessary.
 func (c *Cors) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" && r.Header.Get("Origin") != "" {
+		// null or empty Origin header value is acceptable and it is considered having that header
+		_, hasOriginHeader := r.Header["Origin"]
+
+		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" && hasOriginHeader {
 			c.logf("Handler: Preflight request")
 			c.handlePreflight(w, r)
 			// Preflight requests are standalone and should stop the chain as some other
@@ -246,10 +249,6 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 	headers.Add("Vary", "Access-Control-Request-Method")
 	headers.Add("Vary", "Access-Control-Request-Headers")
 
-	if origin == "" {
-		c.logf("Preflight aborted: empty origin")
-		return
-	}
 	if !c.isOriginAllowed(r, origin) {
 		c.logf("Preflight aborted: origin '%s' not allowed", origin)
 		return
@@ -291,14 +290,17 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 // handleActualRequest handles simple cross-origin requests, actual request or redirects
 func (c *Cors) handleActualRequest(w http.ResponseWriter, r *http.Request) {
 	headers := w.Header()
-	origin := r.Header.Get("Origin")
+	// null Origin header value is acceptable and it is considered having that header
+	_, hasOriginHeader := r.Header["Origin"]
 
 	// Always set Vary, see https://github.com/rs/cors/issues/10
 	headers.Add("Vary", "Origin")
-	if origin == "" {
+
+	if !hasOriginHeader {
 		c.logf("Actual request no headers added: missing origin")
 		return
 	}
+	origin := r.Header.Get("Origin")
 	if !c.isOriginAllowed(r, origin) {
 		c.logf("Actual request no headers added: origin '%s' not allowed", origin)
 		return

--- a/cors.go
+++ b/cors.go
@@ -3,15 +3,15 @@
 //
 // You can configure it by passing an option struct to cors.New:
 //
-//     c := cors.New(cors.Options{
-//         AllowedOrigins: []string{"foo.com"},
-//         AllowedMethods: []string{"GET", "POST", "DELETE"},
-//         AllowCredentials: true,
-//     })
+//	c := cors.New(cors.Options{
+//	    AllowedOrigins: []string{"foo.com"},
+//	    AllowedMethods: []string{"GET", "POST", "DELETE"},
+//	    AllowCredentials: true,
+//	})
 //
 // Then insert the handler in the chain:
 //
-//     handler = c.Handler(handler)
+//	handler = c.Handler(handler)
 //
 // See Options documentation for more options.
 //
@@ -210,7 +210,7 @@ func AllowAll() *Cors {
 // as necessary.
 func (c *Cors) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" && r.Header.Get("Origin") != "" {
 			c.logf("Handler: Preflight request")
 			c.handlePreflight(w, r)
 			// Preflight requests are standalone and should stop the chain as some other


### PR DESCRIPTION
1. Require Origin header to be set to consider a request to be a preflight request
2. Allow empty Origin header - see note https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#origin