### PR TITLE
fix: preserve original method case in CORS preflight responses

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -176,7 +176,7 @@ func New(options Options) *Cors {
 		// Default is spec's "simple" methods
 		c.allowedMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead}
 	} else {
-		c.allowedMethods = convert(options.AllowedMethods, strings.ToUpper)
+		c.allowedMethods = append([]string{}, options.AllowedMethods...)
 	}
 
 	return c
@@ -271,7 +271,13 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 	}
 	// Spec says: Since the list of methods can be unbounded, simply returning the method indicated
 	// by Access-Control-Request-Method (if supported) can be enough
-	headers.Set("Access-Control-Allow-Methods", strings.ToUpper(reqMethod))
+	// Return the method in the case configured by the user, not uppercased
+	for _, m := range c.allowedMethods {
+		if strings.EqualFold(m, reqMethod) {
+			headers.Set("Access-Control-Allow-Methods", m)
+			break
+		}
+	}
 	if len(reqHeaders) > 0 {
 
 		// Spec says: Since the list of headers can be unbounded, simply returning supported headers
@@ -366,13 +372,12 @@ func (c *Cors) isMethodAllowed(method string) bool {
 		// If no method allowed, always return false, even for preflight request
 		return false
 	}
-	method = strings.ToUpper(method)
-	if method == http.MethodOptions {
+	if strings.EqualFold(method, http.MethodOptions) {
 		// Always allow preflight requests
 		return true
 	}
 	for _, m := range c.allowedMethods {
-		if m == method {
+		if strings.EqualFold(m, method) {
 			return true
 		}
 	}

--- a/cors_test.go
+++ b/cors_test.go
@@ -502,3 +502,26 @@ func TestIsMethodAllowedReturnsTrueWithOptions(t *testing.T) {
 		t.Error("IsMethodAllowed should return true when c.allowedMethods is nil.")
 	}
 }
+
+func TestHandlePreflightLowercaseAllowedMethod(t *testing.T) {
+	const (
+		origin = "https://foo.com"
+		method = "patch"
+	)
+	c := New(Options{
+		AllowedOrigins: []string{origin},
+		AllowedMethods: []string{method},
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodOptions, "http://example.com/foo", nil)
+	req.Header.Add("Origin", origin)
+	req.Header.Add("Access-Control-Request-Method", method)
+
+	c.handlePreflight(res, req)
+
+	assertHeaders(t, res.Result().Header, map[string]string{
+		"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":  origin,
+		"Access-Control-Allow-Methods": method,
+	})
+}


### PR DESCRIPTION
Fixes #27

## Summary

Stop uppercasing AllowedMethods at config time and use case-insensitive comparison (strings.EqualFold) for method matching. This preserves the user-configured method case in Access-Control-Allow-Methods responses.

Before this fix, configuring AllowedMethods with lowercase methods (e.g., patch) would result in the response header being uppercased (PATCH), losing the original case.

## Changes

- Store AllowedMethods without uppercasing (preserve user's original case)
- Use strings.EqualFold for case-insensitive method matching
- Return the configured method name in Access-Control-Allow-Methods response header

## Test

Added TestHandlePreflightLowercaseAllowedMethod from #27 — verifies that a lowercase method is preserved in the response.