### PR TITLE
fix: do not implicitly allow OPTIONS in isMethodAllowed

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -367,10 +367,6 @@ func (c *Cors) isMethodAllowed(method string) bool {
 		return false
 	}
 	method = strings.ToUpper(method)
-	if method == http.MethodOptions {
-		// Always allow preflight requests
-		return true
-	}
 	for _, m := range c.allowedMethods {
 		if m == method {
 			return true

--- a/cors_test.go
+++ b/cors_test.go
@@ -376,6 +376,20 @@ func TestSpec(t *testing.T) {
 				"Origin": "http://foobar.com",
 			},
 			map[string]string{
+				"Vary": "Origin",
+			},
+		},
+		{
+			"NonPreflightOptionsAllowed",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedMethods: []string{"GET", "OPTIONS"},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
 				"Vary":                        "Origin",
 				"Access-Control-Allow-Origin": "http://foobar.com",
 			},
@@ -494,11 +508,20 @@ func TestIsMethodAllowedReturnsFalseWithNoMethods(t *testing.T) {
 	}
 }
 
-func TestIsMethodAllowedReturnsTrueWithOptions(t *testing.T) {
+func TestIsMethodAllowedRejectsOptionsByDefault(t *testing.T) {
 	s := New(Options{
-		// Intentionally left blank.
+		// Default methods: GET, POST, HEAD — OPTIONS not included
+	})
+	if s.isMethodAllowed("OPTIONS") {
+		t.Error("IsMethodAllowed should return false for OPTIONS when not in AllowedMethods.")
+	}
+}
+
+func TestIsMethodAllowedAllowsOptionsWhenExplicit(t *testing.T) {
+	s := New(Options{
+		AllowedMethods: []string{"GET", "POST", "OPTIONS"},
 	})
 	if !s.isMethodAllowed("OPTIONS") {
-		t.Error("IsMethodAllowed should return true when c.allowedMethods is nil.")
+		t.Error("IsMethodAllowed should return true for OPTIONS when explicitly in AllowedMethods.")
 	}
 }


### PR DESCRIPTION
## Summary

- Remove the special case in `isMethodAllowed` that always allows OPTIONS requests regardless of AllowedMethods configuration
- Non-preflight OPTIONS requests are now subject to the same method check as other HTTP methods
- Preflight handling is unaffected since `handlePreflight` checks `Access-Control-Request-Method`, not the OPTIONS method itself

## Test Changes

- Updated `TestIsMethodAllowedReturnsTrueWithOptions` to `TestIsMethodAllowedRejectsOptionsByDefault`: verifies OPTIONS is rejected when not in AllowedMethods
- Added `TestIsMethodAllowedAllowsOptionsWhenExplicit`: verifies OPTIONS is allowed when explicitly listed
- Updated `NonPreflightOptions` test: now expects no CORS headers when OPTIONS is not in AllowedMethods
- Added `NonPreflightOptionsAllowed` test: verifies CORS headers are set when OPTIONS is explicitly in AllowedMethods

Closes #37

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>