### PR TITLE
test: clarify error messages in isMethodAllowed tests

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -490,7 +490,7 @@ func TestIsMethodAllowedReturnsFalseWithNoMethods(t *testing.T) {
 	})
 	s.allowedMethods = []string{}
 	if s.isMethodAllowed("") {
-		t.Error("IsMethodAllowed should return false when c.allowedMethods is nil.")
+		t.Error("IsMethodAllowed should return false when c.allowedMethods is empty.")
 	}
 }
 
@@ -499,6 +499,6 @@ func TestIsMethodAllowedReturnsTrueWithOptions(t *testing.T) {
 		// Intentionally left blank.
 	})
 	if !s.isMethodAllowed("OPTIONS") {
-		t.Error("IsMethodAllowed should return true when c.allowedMethods is nil.")
+		t.Error("IsMethodAllowed should return true when OPTIONS is requested with default options.")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #28.

`TestDefault` already uses the corrected `must not be nil` messages on master. This PR fixes the remaining misleading failure messages in the same file:

- `TestIsMethodAllowedReturnsFalseWithNoMethods`: the test sets `allowedMethods` to an empty slice, not nil
- `TestIsMethodAllowedReturnsTrueWithOptions`: describes the actual assertion (OPTIONS allowed with default options)

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`
