### PR TITLE
fix: trim and skip empty AllowedOrigins entries

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -138,7 +138,10 @@ func New(options Options) *Cors {
 		c.allowedWOrigins = []wildcard{}
 		for _, origin := range options.AllowedOrigins {
 			// Normalize
-			origin = strings.ToLower(origin)
+			origin = strings.ToLower(strings.TrimSpace(origin))
+			if origin == "" {
+				continue
+			}
 			if origin == "*" {
 				// If "*" is present in the list, turn the whole list into a match all
 				c.allowedOriginsAll = true

--- a/origin_trim_test.go
+++ b/origin_trim_test.go
@@ -1,0 +1,24 @@
+package cors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAllowedOriginsTrimSpace(t *testing.T) {
+	c := New(Options{
+		AllowedOrigins: []string{" http://example.com ", "", "http://foo.com"},
+		AllowedMethods: []string{"GET"},
+	})
+	h := c.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "http://host/", nil)
+	req.Header.Set("Origin", "http://example.com")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Header().Get("Access-Control-Allow-Origin") != "http://example.com" {
+		t.Fatalf("headers=%v", rr.Header())
+	}
+}


### PR DESCRIPTION
## What

`AllowedOrigins` values are trimmed; empty entries after trim are skipped.

## Why

Config lists often include padding or blank lines. Those should not break origin matching.

## Test

- `TestAllowedOriginsTrimSpace`