### PR TITLE
Do not implicitly allow OPTIONS in CORS config

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -367,10 +367,6 @@ func (c *Cors) isMethodAllowed(method string) bool {
 		return false
 	}
 	method = strings.ToUpper(method)
-	if method == http.MethodOptions {
-		// Always allow preflight requests
-		return true
-	}
 	for _, m := range c.allowedMethods {
 		if m == method {
 			return true

--- a/cors_test.go
+++ b/cors_test.go
@@ -226,6 +226,21 @@ func TestSpec(t *testing.T) {
 			},
 		},
 		{
+			"DisallowedActualOPTIONS",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedMethods: []string{"GET", "POST", "HEAD"},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://foobar.com",
+				"Access-Control-Request-Method": "OPTIONS",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+			},
+		},
+		{
 			"AllowedHeaders",
 			Options{
 				AllowedOrigins: []string{"http://foobar.com"},
@@ -376,8 +391,7 @@ func TestSpec(t *testing.T) {
 				"Origin": "http://foobar.com",
 			},
 			map[string]string{
-				"Vary":                        "Origin",
-				"Access-Control-Allow-Origin": "http://foobar.com",
+				"Vary": "Origin",
 			},
 		},
 	}
@@ -496,9 +510,21 @@ func TestIsMethodAllowedReturnsFalseWithNoMethods(t *testing.T) {
 
 func TestIsMethodAllowedReturnsTrueWithOptions(t *testing.T) {
 	s := New(Options{
-		// Intentionally left blank.
+		AllowedMethods: []string{"GET", "OPTIONS"},
 	})
 	if !s.isMethodAllowed("OPTIONS") {
-		t.Error("IsMethodAllowed should return true when c.allowedMethods is nil.")
+		t.Error("IsMethodAllowed should return true when OPTIONS is configured.")
+	}
+}
+
+func TestIsMethodAllowedDoesNotImplicitlyAllowOptions(t *testing.T) {
+	s := New(Options{
+		AllowedMethods: []string{"GET", "POST", "HEAD"},
+	})
+	if s.isMethodAllowed("OPTIONS") {
+		t.Error("IsMethodAllowed should not allow OPTIONS unless it is listed in AllowedMethods.")
+	}
+	if !s.isMethodAllowed("GET") {
+		t.Error("GET should still be allowed.")
 	}
 }


### PR DESCRIPTION
Fixes #37

`isMethodAllowed` treated OPTIONS as always allowed so a preflight with `Access-Control-Request-Method: OPTIONS` succeeded even when OPTIONS was not in `AllowedMethods`. That lets browsers follow up with an actual OPTIONS request the server did not opt into.

Preflight still works: the HTTP method of the preflight is OPTIONS regardless, and `Access-Control-Allow-Methods` now reflects only configured methods. List OPTIONS explicitly when the server wants to allow non-preflight OPTIONS.